### PR TITLE
readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 # hCore
 
-## What is hCore?
+### [Implement HCore to your project now.](https://hcore.gitbook.io/wiki/#import)
 
-A simplified and multi-functional tool for spigot developers. There are dozens of features you can use in it, and it is
-completely open source code. hCore supports all versions from 1.8.x to 1.19.x. Also, you can find all these APIs usages
-from [here](https://github.com/hakan-krgn/hCore/wiki).
+## What is hCore
 
-## JavaDocs
+A simplified and multi-functional tool for spigot developers. There are dozens of features you can use in it. Also, HCore is
+completely open source code. hCore supports all versions from 1.8.x to 1.19.x.
 
-* https://hakan-krgn.github.io/hCore/api/
-* https://hakan-krgn.github.io/hCore/proxy-client/
-* https://hakan-krgn.github.io/hCore/proxy-server/
-
-## GitBook
-
-* https://hcore.gitbook.io/wiki/UlrGgPjjLVL9eysYaR5X/
+### [GitBook](https://hcore.gitbook.io/wiki)
+### [Wiki](https://github.com/hakan-krgn/hCore/wiki)
 
 ## Developers
 
@@ -35,64 +29,25 @@ from [here](https://github.com/hakan-krgn/hCore/wiki).
 * [@rin-17](https://github.com/rin-17)
 * [@bilektugrul](https://github.com/bilektugrul)
 * [@hamza-cskn](https://github.com/hamza-cskn)
-* [@zhogoshi](https://github.com/zhogoshi)
+* [@hogoshi](https://github.com/zhogoshi)
 
 ## Features
 
-- [`Annotation Command`](https://github.com/hakan-krgn/hCore/wiki/AnnotationCommand) - Command system with annotation for registering commands without plugin.yml.
-- [`NPC`](https://github.com/hakan-krgn/hCore/wiki/NPC) - NPC system for creating and managing client-side NPCs.
-- [`Database`](https://github.com/hakan-krgn/hCore/wiki/Database) - Database implementation system for multi-database support.
-- [`Hologram`](https://github.com/hakan-krgn/hCore/wiki/Hologram) - Hologram system for creating and managing client-side holograms.
-- [`Scoreboard`](https://github.com/hakan-krgn/hCore/wiki/Scoreboard) - Scoreboard system for creating non-flicker scoreboards.
-- [`Message`](https://github.com/hakan-krgn/hCore/wiki/Message) - Message system to send title, action-bar or boss-bar to player.
-- [`Packet`](https://github.com/hakan-krgn/hCore/wiki/Packet) - Packet system to listen to the packet and send it to the player.
-- [`Event Subscriber`](https://github.com/hakan-krgn/hCore/wiki/EventSubscriber) - Event subscribe system to register listeners without any class.
-- [`Particle`](https://github.com/hakan-krgn/hCore/wiki/Particle) - Particle system to play particle effects client-side for any player.
-- [`Renderer`](https://github.com/hakan-krgn/hCore/wiki/Renderer) - Renderer system for rendering and sending the package to the closest players.
-- [`Scheduler`](https://github.com/hakan-krgn/hCore/wiki/Scheduler) - Scheduler system to easily create new scheduler.
-- [`Inventory`](https://github.com/hakan-krgn/hCore/wiki/Inventory) - Inventory system for creating and opening special inventories for players.
-- [`Anvil`](https://github.com/hakan-krgn/hCore/wiki/Anvil) - Anvil system for receiving input from the player.
-- [`Sign`](https://github.com/hakan-krgn/hCore/wiki/Sign) - Sign system for receiving input from the player.
-- [`WorldBorder`](https://github.com/hakan-krgn/hCore/wiki/WorldBorder) - WorldBorder system to display WorldBorder client-side.
-- [`ItemBuilder`](https://github.com/hakan-krgn/hCore/wiki/ItemBuilder) - HItemBuilder class for creating item stacks and manage stacks easily.
-- [`Yaml`](https://github.com/hakan-krgn/hCore/wiki/Yaml) - Basic yaml system for creating and manage YAMLs easily.
-- [`Spam`](https://github.com/hakan-krgn/hCore/wiki/Spam) - Spam system to check if the given ID is spamming.
-
-## How to add it to Maven or Gradle?
-
-### Maven
-
-``` xml
-<repository>
-    <id>jitpack.io</id>
-    <url>https://jitpack.io</url>
-</repository>
-
-<dependency>
-    <groupId>com.github.hakan-krgn.hCore</groupId>
-    <artifactId>bukkit</artifactId>
-    <version>0.6.2</version>
-    <scope>provided</scope>
-</dependency>
-
-
-<!--If you want to use this api without libraries, you can use below dependency -->
-<dependency>
-    <groupId>com.github.hakan-krgn.hCore</groupId>
-    <artifactId>bukkit-primary</artifactId>
-    <version>0.6.2</version>
-    <scope>compile</scope>
-</dependency>
-```
-
-### Gradle
-
-``` xml
-repositories {
-  maven { url 'https://jitpack.io' }
-}
-
-dependencies {
-  implementation 'com.github.hakan-krgn.hCore:bukkit:0.6.2'
-}
-```
+- [`Annotation Commands`](https://hcore.gitbook.io/wiki/messaging/command-system) - Command system with annotation for registering commands.
+- [`NPCs`](https://hcore.gitbook.io/wiki/entities/npc) - NPC system for creating and managing client-side NPCs.
+- [`Databases`](https://hcore.gitbook.io/wiki/others/database-management) - Database implementation system for multi-database support.
+- [`Holograms`](https://hcore.gitbook.io/wiki/entities/holograms) - Hologram system for creating and managing client-side holograms.
+- [`Scoreboards`](https://hcore.gitbook.io/wiki/messaging/scoreboards) - Scoreboard system for creating non-flicker scoreboards.
+- [`Messaging`](https://hcore.gitbook.io/wiki/messaging/messagings) - Message system to send title, action-bar or boss-bar to player.
+- [`Packets`](https://hcore.gitbook.io/wiki/messaging/packets) - Packet system to listen to the packet and send it to the player.
+- [`Event Subscriber`](https://hcore.gitbook.io/wiki/others/event-subscriber) - Event subscribe system to register listeners without any class.
+- [`Particles`](https://hcore.gitbook.io/wiki/entities/particles) - Particle system to play particle effects for any player.
+- [`Renderers`](https://hcore.gitbook.io/wiki/entities/renderers) - Renderer system for rendering and sending the package to the closest players.
+- [`Schedulers`](https://github.com/hakan-krgn/hCore/wiki/Scheduler) - Scheduler system to easily create new scheduler.
+- [`Menus`](https://hcore.gitbook.io/wiki/others/inventories) - Menu system for creating and opening special inventories for players.
+- [`Anvils`](https://github.com/hakan-krgn/hCore/wiki/Anvil) - Anvil system for receiving input from the player.
+- [`Signs`](https://github.com/hakan-krgn/hCore/wiki/Sign) - Sign system for receiving input from the player.
+- [`WorldBorders`](https://hcore.gitbook.io/wiki/others/world-borders) - WorldBorder system to display WorldBorder client-side.
+- [`ItemBuilder`](https://hcore.gitbook.io/wiki/others/itembuilder) - HItemBuilder class for creating item stacks and manage stacks easily.
+- [`Configurations`](https://hcore.gitbook.io/wiki/configs/configs) - YAML and JSON config system for creating and manage configs easily.
+- [`Spam`](https://hcore.gitbook.io/wiki/messaging/spam-system) - Spam system to check if the given ID is spamming.


### PR DESCRIPTION
• Gitbook link opened, so, now url is much simple.
• No need to paste alot of code how to implement hcore, so, just kept the link to gitbook.
• Some features descriptions changed, merged YAML and JSON configs.
• Renamed inventories to menus.
• Now all features links sends to gitbook's pages (include schedulers, anvils and signs. how about merge anvils and signs to menus??).

well, prob some changes is bad, but, anyway, they should be probably.