### PR TITLE
update renderer code

### DIFF
--- a/hCore-bukkit/api/src/main/java/com/hakan/core/renderer/Renderer.java
+++ b/hCore-bukkit/api/src/main/java/com/hakan/core/renderer/Renderer.java
@@ -337,8 +337,11 @@ public final class Renderer {
             return this.viewers;
 
         Set<UUID> viewers = new HashSet<>();
-        this.location.getWorld().getPlayers()
-                .forEach(player -> viewers.add(player.getUniqueId()));
+        Bukkit.getOnlinePlayers()
+                .stream()
+                .filter(player -> player.getWorld().equals(this.location.getWorld()))
+                .map(Player::getUniqueId)
+                .forEach(viewers::add);
         return viewers;
     }
 


### PR DESCRIPTION
CraftWorld.getPlayers loops all the entities in the specified world. It is **WAY** better to use getOnlinePlayers and filter them.